### PR TITLE
Add RSSI to uat2json and uat2text output.

### DIFF
--- a/extract_nexrad.c
+++ b/extract_nexrad.c
@@ -264,7 +264,7 @@ void decode_nexrad(struct fisb_apdu *fisb)
     }
 }
 
-void handle_frame(frame_type_t type, uint8_t *frame, int len, void *extra)
+void handle_frame(frame_type_t type, uint8_t *frame, int len, void *extra, float ss)
 {
     if (type == UAT_UPLINK) {
         struct uat_uplink_mdb mdb;

--- a/reader.c
+++ b/reader.c
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
@@ -151,8 +152,13 @@ static int process_line(struct dump978_reader *reader, frame_handler_t handler, 
         int byte;
                 
         if (p[0] == ';') {
+            p++;
+            float signal_strength = 0;
+            if (p[0] == 's')
+                sscanf(p, "ss=%f;", &signal_strength);
+
             // ignore rest of line
-            handler(frametype, reader->frame, len, handler_data);
+            handler(frametype, reader->frame, len, handler_data, signal_strength);
             return 1;
         }
         

--- a/reader.h
+++ b/reader.h
@@ -30,10 +30,11 @@ typedef enum { UAT_UPLINK, UAT_DOWNLINK } frame_type_t;
 //   f: pointer to frame data buffer
 //   l: length of frame data
 //   d: value of handler_data passed to dump978_read_frames
+//  ss: measured signal strength in dBFS
 // The frame data buffer is a shared buffer owned by the caller
 // and may be reused after return; if the handler needs to
 // preserve the data after returning, it should take a copy.
-typedef void (*frame_handler_t)(frame_type_t t,uint8_t *f,int l,void *d);
+typedef void (*frame_handler_t)(frame_type_t t,uint8_t *f,int l,void *d, float ss);
 
 // Allocate a new reader that reads from file descriptor 'fd'.
 // If 'nonblock' is nonzero, the FD will be made nonblocking.

--- a/uat2esnt.c
+++ b/uat2esnt.c
@@ -655,7 +655,7 @@ static int should_send(struct uat_adsb_mdb *mdb)
     }
 }
 
-static void handle_frame(frame_type_t type, uint8_t *frame, int len, void *extra)
+static void handle_frame(frame_type_t type, uint8_t *frame, int len, void *extra, float ss)
 {
     if (type == UAT_DOWNLINK) {
         struct uat_adsb_mdb mdb;

--- a/uat2text.c
+++ b/uat2text.c
@@ -21,7 +21,7 @@
 #include "uat_decode.h"
 #include "reader.h"
 
-void handle_frame(frame_type_t type, uint8_t *frame, int len, void *extra)
+void handle_frame(frame_type_t type, uint8_t *frame, int len, void *extra, float signal_strength)
 {
     if (type == UAT_DOWNLINK) {
         struct uat_adsb_mdb mdb;
@@ -33,7 +33,7 @@ void handle_frame(frame_type_t type, uint8_t *frame, int len, void *extra)
         uat_display_uplink_mdb(&mdb, stdout);
     }
 
-    fprintf(stdout, "\n");
+    fprintf(stdout, "RSSI:               %.1f dBFS\n\n", signal_strength);
     fflush(stdout);
 }        
 


### PR DESCRIPTION
This is my attempt to get RSSI into dump978.  It's a bit of a mixture between the stratux fork and dump1090-mutability RSSI.  

It currently only affects uat2json and uat2text.  uat2esnt would be great but I'm not aware of anyway to include the information in what is sent.

It seems to be working fine here but would like to see a few more people use it and confirm what I'm seeing.

Also open to suggestions for improvements or corrections to anything that is found.